### PR TITLE
Class schedule home fix

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -94,10 +94,10 @@
     <plugin name="cordova-plugin-network-information" spec="^2.0.1" />
     <plugin name="cordova-plugin-statusbar" spec="^2.4.1" />
     <plugin name="cordova-plugin-advanced-http" spec="^1.11.1" />
-    <plugin name="cordova-plugin-appavailability" spec="^0.4.2" />
     <plugin name="cordova-plugin-device" spec="^2.0.2" />
     <plugin name="cordova-plugin-splashscreen" spec="^5.0.2" />
     <plugin name="cordova-plugin-ionic-webview" spec="^1.2.0" />
     <plugin name="cordova-plugin-ionic-keyboard" spec="^2.0.5" />
     <plugin name="cordova-plugin-inappbrowser" spec="^2.0.2" />
+    <plugin name="cordova-plugin-appavailability" spec="^0.4.2" />
 </widget>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -87,7 +87,7 @@ export class MyApp {
     if( !params) params = {};
     this.navCtrl.push(CalendarPage);
   }
-  
+
   goToBuildingHours(params){
 	  if( !params) params = {};
 	  this.navCtrl.setRoot(BuildingHoursPage);
@@ -99,20 +99,20 @@ export class MyApp {
 
   checkFacebook(){
   let app;
- 
+
     if (this.platform.is('ios')) {
       app = 'fb://';
     } else if (this.platform.is('android')) {
       app = 'com.facebook.katana';
     }
- 
+
     this.appAvailability.check(app)
       .then(
       (yes: boolean) => this.hasFacebook='Available',
       (no: boolean) => this.hasFacebook='Not Available'
       );
   }
-  
+
   openFacebook(){
 	this.checkFacebook();
 	if(this.hasFacebook=='Available'){
@@ -121,7 +121,7 @@ export class MyApp {
 	this.inAppBrowser.create("https://www.facebook.com/LewisClarkState/",'_system','location=no');
 	}
   }
-  
+
   isCredentialed() : boolean {
     return this.userState.getUserState() == UserState.Credentialed;
   }
@@ -133,6 +133,6 @@ export class MyApp {
   logout() {
     this.credentialsProvider.clearWarriorWebCredentials();
     this.scheduleServiceProvider.clearCache();
-    this.goToLogin({});
+    this.goToLoginNoReuse();
   }
 }

--- a/src/pages/class-schedule/class-schedule.html
+++ b/src/pages/class-schedule/class-schedule.html
@@ -14,8 +14,15 @@
 		<h1>Class Schedule</h1>
 		<ion-list>
 			<ion-item *ngFor="let item of scheduleItems">
-				<h2>{{item.name}}</h2>
+				<h2>{{item.title}} - {{item.name}}</h2>
+				<h3 text-wrap>{{item.description}}</h3><br>
+				<div *ngFor="let instructor of item.faculty">
+					Instructor(s):<br>
+					<h3><b>{{instructor}}</b></h3>
+				</div>
+				<hr>
 				<div *ngFor="let meeting of item.meetings">
+					<h3>Days: {{meeting.daysStr}}</h3>
 					<h3>{{meeting.building}}</h3>
 					<h3>Room {{meeting.room}}</h3>
 					<h4>{{meeting.startTime}} - {{meeting.endTime}}</h4>

--- a/src/pages/login/login.ts
+++ b/src/pages/login/login.ts
@@ -3,6 +3,7 @@ import { IonicPage, NavController, NavParams } from 'ionic-angular';
 import { HomePage } from '../home/home';
 import { CredentialsProvider } from "../../providers/credentials/credentials";
 import { UserStateProvider, UserState } from "../../providers/user-state/user-state";
+import { Platform } from 'ionic-angular';
 
 @IonicPage()
 @Component({
@@ -16,19 +17,20 @@ export class LoginPage {
 	constructor(public navCtrl: NavController,
 		private credentialsProvider: CredentialsProvider,
 		navParams: NavParams,
-		private userState: UserStateProvider) {
+		private userState: UserStateProvider,
+		private platform : Platform) {
 
-		let reuse: boolean = true;
-
-		if (navParams && navParams.get('reuse') != null) { reuse = navParams.get('reuse') };
-
-		if (reuse) {
-			this.credentialsProvider.warriorWebCredentialsExist().then(status => {
-				if (status) {
-					this.handleLogin();
-				}
-			});
-		}
+		this.platform.ready().then((source) => {
+			let reuse: boolean = true;
+			if (navParams && navParams.get('reuse') != null) { reuse = navParams.get('reuse') };
+			if (reuse) {
+				this.credentialsProvider.warriorWebCredentialsExist().then(status => {
+					if (status) {
+						this.handleLogin();
+					}
+				});
+			}
+		});
 	}
 
 	goToHomePage(params) {

--- a/src/providers/credentials/credentials.ts
+++ b/src/providers/credentials/credentials.ts
@@ -29,6 +29,7 @@ export class CredentialsProvider {
 
   async clearWarriorWebCredentials() {
     let storage = await this.secureStorage.create(this.credentials_warriorweb);
+    storage.clear();
     await storage.remove(this.username_warriorweb);
     await storage.remove(this.password_warriorweb);
   }

--- a/src/providers/schedule-service/schedule-service.ts
+++ b/src/providers/schedule-service/schedule-service.ts
@@ -99,6 +99,8 @@ export class ScheduleServiceProvider {
 
 			let meetings = this.courseDataDayLookup[day];
 
+			meetings = (meetings == null) ? [] : meetings;
+
 			handler(meetings);
 		});
 	}
@@ -166,7 +168,8 @@ export class ScheduleServiceProvider {
 					days: days,
 					title: course.Title,
 					name: course.Name,
-					daySecond: daySecond
+					daySecond: daySecond,
+					daysStr : this._computeDaysStr(days),
 				};
 
 				meetings.push(meeting_obj);
@@ -180,11 +183,43 @@ export class ScheduleServiceProvider {
 				title: course.Title,
 				name: course.CourseName,
 				meetings: meetings,
+				faculty: course.Section.Faculty,
+				description : course.Description,
 			};
 
 			result.push(item);
 		}
 
+		return result;
+	}
+
+	_computeDaysStr(days) {
+		let result = "";
+		for(var day of days) {
+			if(day == 0) {
+				result += "Sunday,";
+			}
+			else if(day == 1) {
+				result += "Monday,";
+			}
+			else if(day == 2) {
+				result += "Tuesday,";
+			}
+			else if(day == 3) {
+			  result += "Wednesday,";
+			}
+			else if(day == 4) {
+				result += "Thursday,";
+			}
+			else if(day == 5) {
+			 result += "Friday,";
+			}
+			else if(day == 6) {
+			  result += "Saturday,";
+			}
+		}
+
+		result = (result.endsWith(",")) ? result.substring(0, result.length - 1) : result;
 		return result;
 	}
 


### PR DESCRIPTION
Fixed the following bugs and detailed the class schedule page a bit.

Fix #1: Having an empty schedule for the day won't break the homepage.
Fix #2: iOS devices can now logout fine.
Fix #3: iOS devices can now remember login credentials properly.

Class schedule page detailing:
Satisfied Clancy's complaints. Also added a days listing for displayed meetings.