### PR TITLE
Login will timeout after 30 seconds if warrior web doesn't first.

### DIFF
--- a/src/providers/credentials/credentials.ts
+++ b/src/providers/credentials/credentials.ts
@@ -73,10 +73,14 @@ export class CredentialsProvider {
 
 			let browser: InAppBrowserObject = this.inAppBrowser.create(this.warrior_web_link, '_blank', 'clearcache=yes,hidden=yes');
 
+			let has_completed = false;
+
 			setTimeout(() => {
-				browser.close();
-				loader.dismiss();
-				handler(false);
+				if(!has_completed) {
+					browser.close();
+					loader.dismiss();
+					handler(false);
+				}
 			}, 30000);
 
 			let load_count = 0;
@@ -98,6 +102,7 @@ export class CredentialsProvider {
 						handler(result.toString() == "true"); // Implicit bool conversion any -> boolean seems to fail :/
 						loader.dismiss();
 						browser.close();
+						has_completed = true;
 					});
 				}
 

--- a/src/providers/credentials/credentials.ts
+++ b/src/providers/credentials/credentials.ts
@@ -66,11 +66,18 @@ export class CredentialsProvider {
 			content: 'Accessing Warrior Web...'
 		});
 
+
 		loader.present().then(async () => {
 			let username = await this.getWarriorWebUsername();
 			let password = await this.getWarriorWebPassword();
 
 			let browser: InAppBrowserObject = this.inAppBrowser.create(this.warrior_web_link, '_blank', 'clearcache=yes,hidden=yes');
+
+			setTimeout(() => {
+				browser.close();
+				loader.dismiss();
+				handler(false);
+			}, 30000);
 
 			let load_count = 0;
 


### PR DESCRIPTION
Sometimes Warrior Web instead of timing out will try to load for a long duration. Previously this locked the app logout essentially, as it would never timeout and guest mode couldn't be used. Now after 30 seconds the app will force the loading controller to dismiss and for the credentials provider to assume that at the moment Warrior Web is not available.